### PR TITLE
Fix copy/paste bug in unit test data samples.

### DIFF
--- a/csharp/roslyn-sdk/Tutorials/MakeConst/MakeConst.Test/MakeConstUnitTests.cs
+++ b/csharp/roslyn-sdk/Tutorials/MakeConst/MakeConst.Test/MakeConstUnitTests.cs
@@ -234,7 +234,7 @@ namespace MakeConstTest
     {
         static void Main(string[] args)
         {
-            var item = 4;
+            var item = ""abc"";
         }
     }
 }";
@@ -247,7 +247,7 @@ namespace MakeConstTest
     {
         static void Main(string[] args)
         {
-            const int item = 4;
+            const string item = ""abc"";
         }
     }
 }";


### PR DESCRIPTION
## Fix copy/paste bug in Roslyn tutorial unit test data samples.

There are unit test examples for integers and strings, but the string unit tests mirror the integer unit tests.  This fix simply gives the string unit tests the expected initialization values.

Fixes dotnet/docs#11826
